### PR TITLE
Enable map centering on a ship using IMO or MMSI from URL

### DIFF
--- a/webapp/app/Http/Controllers/ShipController.php
+++ b/webapp/app/Http/Controllers/ShipController.php
@@ -166,4 +166,26 @@ class ShipController extends Controller
     {
         return response($file, 200)->header('Content-Type', 'image/jpeg');
     }
+
+    /**
+     * Fetches ship data based on IMO or MMSI and returns coordinates for map centering.
+     */
+    public function center(Request $request)
+    {
+        $imo = $request->query('imo');
+        $mmsi = $request->query('mmsi');
+
+        $ship = ShipLatestPositionView::when($imo, function ($query, $imo) {
+            return $query->where('imo', $imo);
+        })->when($mmsi, function ($query, $mmsi) {
+            return $query->where('mmsi', $mmsi);
+        })->first();
+
+        if ($ship) {
+            $coordinates = json_decode($ship->geojson)->coordinates;
+            return response()->json(['coordinates' => $coordinates]);
+        } else {
+            return response()->json(['message' => 'Ship not found'], 404);
+        }
+    }
 }

--- a/webapp/resources/js/Components/ShipLayer.vue
+++ b/webapp/resources/js/Components/ShipLayer.vue
@@ -69,6 +69,15 @@ export default {
         this.mapInstance.on("rotateend", () => {
             this.isMapInteracting = false; // User stopped rotating the map
         });
+
+        // Capture and parse URL parameters for IMO or MMSI
+        const urlParams = new URLSearchParams(window.location.search);
+        const imo = urlParams.get("imo");
+        const mmsi = urlParams.get("mmsi");
+
+        if (imo || mmsi) {
+            await this.centerMapOnShip(imo, mmsi);
+        }
     },
 
     computed: {
@@ -152,6 +161,22 @@ export default {
 
             // Schedule the next frame using requestAnimationFrame
             requestAnimationFrame(() => this.updateLoop());
+        },
+
+        async centerMapOnShip(imo, mmsi) {
+            try {
+                const response = await fetch(`/api/ships/center?imo=${imo}&mmsi=${mmsi}`);
+                const data = await response.json();
+
+                if (data && data.coordinates) {
+                    this.mapInstance.setCenter(data.coordinates);
+                    this.mapInstance.setZoom(12);
+                } else {
+                    console.error("Ship not found or invalid coordinates");
+                }
+            } catch (error) {
+                console.error("API Error:", error);
+            }
         },
     },
 };

--- a/webapp/resources/js/Helpers/MapHelper.js
+++ b/webapp/resources/js/Helpers/MapHelper.js
@@ -121,4 +121,10 @@ export default {
         map.addControl(draw); // Add the control to the map
         return draw; // Return the draw control instance
     },
+
+    // Add a method to center the map on given coordinates
+    centerMapOnCoordinates(map, coordinates) {
+        map.setCenter(coordinates);
+        map.setZoom(12);
+    },
 };

--- a/webapp/routes/api.php
+++ b/webapp/routes/api.php
@@ -22,6 +22,9 @@ Route::get('/ships/realtime/search', [ShipController::class, 'search'])->name('s
 // Real-time ship details
 Route::get('/ships/details/{mmsi}', [ShipController::class, 'details'])->name('ships.details');
 
+// Fetch ship data based on IMO or MMSI
+Route::get('/ships/center', [ShipController::class, 'center'])->name('ships.center');
+
 // Protected routes
 Route::middleware('auth:sanctum')->group(function () {
     // Your protected routes here

--- a/webapp/routes/web.php
+++ b/webapp/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\LdapController;
 use App\Http\Controllers\RoleController;
 use App\Http\Controllers\LayerController;
 use App\Http\Controllers\SearouteController;
+use App\Http\Controllers\ShipController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -48,5 +49,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/searoutes/geojson', [SearouteController::class, 'geojson'])->name('searoutes.geojson');
     Route::resource('searoutes', SearouteController::class);
 });
+
+// Add a route to handle URL parameters for map centering
+Route::get('/ships/center', [ShipController::class, 'center'])->name('ships.center');
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
Fixes #57

Add feature to center map on a ship using IMO or MMSI from URL parameters.

* **ShipLayer.vue**: Capture and parse URL parameters for IMO or MMSI, fetch ship data based on parsed parameters, and center the map on the ship if found.
* **MapHelper.js**: Add a method to center the map on given coordinates.
* **api.php**: Add a route to fetch ship data based on IMO or MMSI.
* **web.php**: Add a route to handle URL parameters for map centering.
* **ShipController.php**: Add a method to fetch ship data based on IMO or MMSI and return coordinates for map centering.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/geoglify/geoglify/pull/61?shareId=9c66af7b-f7a1-4e7f-ace7-2577e75a4c46).